### PR TITLE
Fix stepsToPercentage() using wrong variable

### DIFF
--- a/code/src/stepper_motor.cc
+++ b/code/src/stepper_motor.cc
@@ -394,7 +394,7 @@ float StepperMotor::getPositionPercentageExact() {
  * @return The percentage the number of steps represents.
  */
 float StepperMotor::stepsToPercentage(uint64_t steps) {
-  return ((100.0 * this->step_position) /
+  return ((100.0 * steps) /
           (WINDOW_WIDTH_MM * SM_FULL_STEPS_PER_MM * SM_SMALLEST_MS));
 };
 


### PR DESCRIPTION
## Summary

Fix bug in `stepsToPercentage()` function that was using the wrong variable.

## The Bug

The function was incorrectly using `this->step_position` instead of the `steps` parameter:

```cpp
// Before (bug)
float StepperMotor::stepsToPercentage(uint64_t steps) {
  return ((100.0 * this->step_position) /  // <-- wrong variable!
          (WINDOW_WIDTH_MM * SM_FULL_STEPS_PER_MM * SM_SMALLEST_MS));
};

// After (fix)
float StepperMotor::stepsToPercentage(uint64_t steps) {
  return ((100.0 * steps) /  // <-- correct parameter
          (WINDOW_WIDTH_MM * SM_FULL_STEPS_PER_MM * SM_SMALLEST_MS));
};
```

## Impact

This caused the function to always return the current position percentage regardless of the input argument, making it useless for converting arbitrary step values.

## Test plan

- [ ] Verify `stepsToPercentage(0)` returns 0%
- [ ] Verify `stepsToPercentage(WINDOW_OPEN_STEP_POSITION)` returns 100%
- [ ] Verify arbitrary step values convert correctly