### PR TITLE
Add hardware watchdog timer for system reliability

### DIFF
--- a/code/src/main.cc
+++ b/code/src/main.cc
@@ -1,4 +1,5 @@
 #include <hardware/gpio.h>
+#include <hardware/watchdog.h>
 #include <pico/cyw43_arch.h>
 #include <pico/stdio.h>
 // #include <pico/time.h>
@@ -174,6 +175,13 @@ int main() {
   window_sm.home();
   printf("Homeing Complete.\n");
 
+  // Enable the hardware watchdog timer.
+  // If watchdog_update() is not called within 8 seconds, the device will reset.
+  // This prevents the device from getting stuck in an infinite loop.
+  printf("Enabling watchdog timer...\n");
+  watchdog_enable(8000, 1);  // 8 second timeout, pause on debug
+  printf("Watchdog enabled.\n");
+
   /*
   **=========================================================================**
   ||                                                                         ||
@@ -188,6 +196,9 @@ int main() {
 
   unsigned int loop_iteration = 0;
   while (true) {
+    // Feed the watchdog to prevent reset.
+    watchdog_update();
+
     // If the network connection is down, set the red LED on and attempt to
     // reconnect.
     if (cyw43_wifi_link_status(&cyw43_state, CYW43_ITF_STA) !=

--- a/code/src/network.cc
+++ b/code/src/network.cc
@@ -5,6 +5,7 @@
 // #include <cyw43_ll.h>
 // #include <hardware/gpio.h>
 // #include <lwip/netif.h>
+#include <hardware/watchdog.h>
 #include <math.h>
 #include <pico/cyw43_arch.h>
 // #include <pico/error.h>
@@ -58,6 +59,9 @@ int wifiConnect() {
   int connect_attempt = 0;
   while (connect_attempt++ != WIFI_CONNECTION_MAX_ATTEMPTS &&
          link_state != CYW43_LINK_JOIN) {
+    // Feed the watchdog during potentially long connection attempts.
+    watchdog_update();
+
     // If not the first connection attempt, print out the attempt number and the
     // link state.
     if (connect_attempt > 1) {
@@ -139,6 +143,7 @@ int wifiConnect() {
           sleep_ms(50);
           cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 1);
           sleep_ms(100);
+          watchdog_update();  // Feed watchdog during retry
         }
 
         // Update the link state.

--- a/code/src/stepper_motor.cc
+++ b/code/src/stepper_motor.cc
@@ -1,5 +1,6 @@
 #include "stepper_motor.hh"
 
+#include <hardware/watchdog.h>
 #include <math.h>
 #include <pico/cyw43_arch.h>
 #include <pico/platform/compiler.h>
@@ -443,6 +444,9 @@ void StepperMotor::stepExact(uint64_t half_step_delay) {
   // // Option B:
   // this->step_position +=
   //     (1 - 2 * this->getDir()) * (SM_SMALLEST_MS / this->getMicroStepInt());
+
+  // Feed the watchdog during long motor operations to prevent reset.
+  watchdog_update();
 }
 
 /**


### PR DESCRIPTION
## Summary

Add RP2040 hardware watchdog timer to automatically reset the device if it hangs, improving system reliability.

## Changes

### main.cc
- Added `#include <hardware/watchdog.h>`
- Enable watchdog with 8-second timeout after homing completes
- Feed watchdog at start of each main loop iteration

### stepper_motor.cc
- Added `#include <hardware/watchdog.h>`
- Feed watchdog in `stepExact()` function (called by all motor operations)

### network.cc
- Added `#include <hardware/watchdog.h>`
- Feed watchdog during WiFi reconnection loop
- Feed watchdog during retry LED blink

## How It Works

```cpp
// Enable after setup (8 second timeout)
watchdog_enable(8000, 1);

// Must be called before timeout expires
watchdog_update();
```

If `watchdog_update()` is not called within 8 seconds, the RP2040 hardware automatically resets the device.

## Coverage

The watchdog is fed in:
1. **Main loop** - Every iteration
2. **Motor stepping** - Every step (via `stepExact()`)
3. **WiFi reconnection** - During connection retry loop

## Test plan

- [ ] Verify device boots normally with watchdog enabled
- [ ] Verify motor operations complete without triggering reset
- [ ] Verify WiFi reconnection works without triggering reset
- [ ] (Optional) Test watchdog triggers reset when loop is artificially blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)